### PR TITLE
Add Load balancing resources

### DIFF
--- a/dev/terraform.tf
+++ b/dev/terraform.tf
@@ -14,7 +14,7 @@ module "network" {
   eip               = "default"
   igw_dest_cidr     = "0.0.0.0/0"
   nat_dest_cidr     = "0.0.0.0/0"
-
+  
 }
 
 
@@ -29,26 +29,7 @@ module "compute" {
   instance_name      = ["web-001","web-002","web-003"]
   security_group     = "${module.network.sg-web}"
   assoc_public_ip    = "true"
-  subnet_id          = ["${module.network.sn-red}"]
-  target_group_arn   = "${element(module.alb.target_group_arns, 0)}"
-
-}
-
-
-
-### Module pulled on Terraform init from HashiCorp Terraform Registry 
-
-module "alb" {
-  source                        = "terraform-aws-modules/alb/aws"
-  load_balancer_name            = "my-alb"
-  security_groups               = ["${module.network.sg-web}"]
-  subnets                       = ["${module.network.sn-red}"]
-  tags                          = "${map("Environment", "test")}"
-  vpc_id                        = "${module.network.vpc_id}"
-  http_tcp_listeners            = "${list(map("port", "80", "protocol", "HTTP"))}"
-  http_tcp_listeners_count      = "1"
-  target_groups                 = "${list(map("name", "web-tg", "backend_protocol", "HTTP", "backend_port", "80"))}"
-  target_groups_count           = "1"
-  logging_enabled               = "false"
-  
+  subnet_id          = ["${module.network.dmz}"]
+  trgt_grp_arn      = "${module.network.lb-trgt-grp-arn}"
+ 
 }

--- a/modules/compute/compute.tf
+++ b/modules/compute/compute.tf
@@ -15,16 +15,17 @@ resource "aws_instance" "web-instance" {
   associate_public_ip_address = "${var.assoc_public_ip}"
   subnet_id             = "${element(var.subnet_id, count.index)}"
 
-
   tags = "${merge(
      local.common_tags,
      map(
      "Name", "instance-${element(var.instance_name, count.index)}"))}"
   }
 
-resource "aws_lb_target_group_attachment" "test" {
-  count             = "${var.target_group_arn == "" ? 0 : var.ec2_num}"
-  target_group_arn = "${var.target_group_arn}"
+
+### Application Load Balancer: Target Group Attachment ###
+
+resource "aws_lb_target_group_attachment" "lb-tg-attach" {
+  target_group_arn = "${var.trgt_grp_arn}"
   target_id        = "${element(aws_instance.web-instance.*.id, count.index)}"
   port             = 80
 }

--- a/modules/compute/input.tf
+++ b/modules/compute/input.tf
@@ -35,7 +35,6 @@ variable "security_group" {
 variable "subnet_id" {
   type = "list"
 }
-variable "target_group_arn" {
-  type = "string"
-  default = ""
+variable "trgt_grp_arn" {
+  
 }

--- a/modules/network/input.tf
+++ b/modules/network/input.tf
@@ -49,4 +49,3 @@ variable "pub_ip_on_launch" {
 variable "igw_dest_cidr" {
   
 }
-

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,10 +1,15 @@
 output "sg-web" {
   value = "${aws_security_group.sg-web.id}"
 }
+output "sg-alb" {
+  value = "${aws_security_group.sg-alb.id}"
+}
 output "vpc_id" {
   value = "${aws_vpc.vpc_base.id}"
 }
-output "sn-red" {
+output "dmz" {
   value = "${aws_subnet.red.*.id}"
 }
-
+output "lb-trgt-grp-arn" {
+  value = "${aws_lb_target_group.lb-tg-web.arn}"
+}


### PR DESCRIPTION
This PR adds Load Balancing resources to the network and compute modules;

- network.tf
- aws_lb
-aws_lb_listener
- aws_lb_target_group
+ aws_security_group for ALB (this needs review)

compute.tf
- aws_lb_target_group_attachment